### PR TITLE
User can only see his/her own albums when logged in

### DIFF
--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -1,7 +1,7 @@
 class PhotosController < ApplicationController
 
   def index
-    @photos = Photo.order(created_at: :desc)
+    @photos = current_user.photos 
   end
 
   def new

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
 
   belongs_to :family, optional: true
   has_many :albums, through: :family
+  has_many :photos, through: :albums
 
   validates :family, presence: true, unless: :is_invited
 

--- a/features/step_definitions/image_and_album_steps.rb
+++ b/features/step_definitions/image_and_album_steps.rb
@@ -40,3 +40,7 @@ end
 Then("the last album should belong to {string} family") do |family_name|
   family = Family.find_by(name: family_name)
   expect(Family.last.name).to eq family.name end
+
+Then("I should not see {string}") do |content|
+  expect(page).not_to have_content content # Write code here that turns the phrase above into concrete actions
+end

--- a/features/step_definitions/image_and_album_steps.rb
+++ b/features/step_definitions/image_and_album_steps.rb
@@ -42,5 +42,5 @@ Then("the last album should belong to {string} family") do |family_name|
   expect(Family.last.name).to eq family.name end
 
 Then("I should not see {string}") do |content|
-  expect(page).not_to have_content content # Write code here that turns the phrase above into concrete actions
+  expect(page).not_to have_content content 
 end

--- a/features/step_definitions/sign_up_log_in_steps.rb
+++ b/features/step_definitions/sign_up_log_in_steps.rb
@@ -8,8 +8,8 @@ Given('I am logged in as {string}') do |user_email|
 end
 
 Then('a family should have been created in the database') do
-  @family = Family.last
-  expect(@family).not_to be nil
+  family = Family.last
+  expect(family).not_to be nil
 end
 
 Then("I should see {string} and {string}") do |content, user_email|

--- a/features/user_can_only_see_albums_connected_to_her_own_family.feature
+++ b/features/user_can_only_see_albums_connected_to_her_own_family.feature
@@ -1,0 +1,36 @@
+Feature: User can only see albums connected to her/his own family when logged in
+  As a user,
+  In order to protect my shared photos
+  I would like to see my own family's photos
+
+ Scenario:
+   When I visit the index page
+   And I click "Sign up"
+   Then I should be redirected to the "Sign up" page
+   When I fill in "Email" with "lisa@gmail.com"
+   And I fill in "Password" with "heythere12"
+   And I fill in "Password confirmation" with "heythere12"
+   Then I fill in "Family name" with "The Simpsons"
+   And I click "Sign up" button
+   Then a family should have been created in the database
+   And the new user's family should be "The Simpsons"
+   When I click "New album"
+   And I fill in "Title" with "Lisa's renovation"
+   And I click "Create album"
+   And the last album should have title "Lisa's renovation"
+   And the last album should belong to "The Simpsons" family
+   When I click "Log out"
+   Then I should see "Signed out successfully."
+   When I visit the index page
+   And I click "Sign up"
+   Then I should be redirected to the "Sign up" page
+   When I fill in "Email" with "sophie@gmail.com"
+   And I fill in "Password" with "heythere12"
+   And I fill in "Password confirmation" with "heythere12"
+   Then I fill in "Family name" with "The Simpsons"
+   And I click "Sign up" button
+   Then a family should have been created in the database
+   And the new user's family should be "The Simpsons"
+   When I click "Shared albums"
+   Then I should be redirected to the "Shared albums" page
+   And I should not see "Lisa's renovation"

--- a/features/user_can_only_see_albums_connected_to_her_own_family.feature
+++ b/features/user_can_only_see_albums_connected_to_her_own_family.feature
@@ -1,36 +1,55 @@
-Feature: User can only see albums connected to her/his own family when logged in
-  As a user,
+Feature: User can only see photos connected to her account
+  As a user
   In order to protect my shared photos
-  I would like to see my own family's photos
+  I would like to only see photos connected to my account
 
- Scenario:
+ Scenario: User can only see albums connected to her account
    When I visit the index page
    And I click "Sign up"
-   Then I should be redirected to the "Sign up" page
-   When I fill in "Email" with "lisa@gmail.com"
+   And I fill in "Email" with "lisa@gmail.com"
    And I fill in "Password" with "heythere12"
    And I fill in "Password confirmation" with "heythere12"
-   Then I fill in "Family name" with "The Simpsons"
+   And I fill in "Family name" with "The Simpsons"
    And I click "Sign up" button
-   Then a family should have been created in the database
-   And the new user's family should be "The Simpsons"
+   Then the new user's family should be "The Simpsons"
    When I click "New album"
    And I fill in "Title" with "Lisa's renovation"
    And I click "Create album"
    And the last album should have title "Lisa's renovation"
    And the last album should belong to "The Simpsons" family
-   When I click "Log out"
-   Then I should see "Signed out successfully."
-   When I visit the index page
+   Then I click "Log out"
    And I click "Sign up"
-   Then I should be redirected to the "Sign up" page
-   When I fill in "Email" with "sophie@gmail.com"
+   And I fill in "Email" with "sophie@gmail.com"
    And I fill in "Password" with "heythere12"
    And I fill in "Password confirmation" with "heythere12"
-   Then I fill in "Family name" with "The Simpsons"
+   And I fill in "Family name" with "The Simpsons"
    And I click "Sign up" button
-   Then a family should have been created in the database
-   And the new user's family should be "The Simpsons"
-   When I click "Shared albums"
-   Then I should be redirected to the "Shared albums" page
-   And I should not see "Lisa's renovation"
+   And I click "Shared albums"
+   Then I should not see "Lisa's renovation"
+
+ Scenario: User can only see photos connected to her account
+   When I visit the index page
+   And I click "Sign up"
+   And I fill in "Email" with "lisa@gmail.com"
+   And I fill in "Password" with "heythere12"
+   And I fill in "Password confirmation" with "heythere12"
+   And I fill in "Family name" with "The Simpsons"
+   And I click "Sign up" button
+   Then the new user's family should be "The Simpsons"
+   When I click "New album"
+   And I fill in "Title" with "Lisa's renovation"
+   And I click "Create album"
+   And I click "Add photo"
+   And I fill in "Title" with "Something"
+   And I upload file "random.png"
+   And I click "Upload"
+   And I click "Log out"
+   And I click "Sign up"
+   And I fill in "Email" with "sophie@gmail.com"
+   And I fill in "Password" with "heythere12"
+   And I fill in "Password confirmation" with "heythere12"
+   And I fill in "Family name" with "The Simpsons"
+   And I click "Sign up" button
+   And I click "My albums"
+   Then I should not see "random.png"
+   And I should not see "Something"


### PR DESCRIPTION
## PT-Link: https://www.pivotaltracker.com/story/show/154997944

### Description 
- Add testing scenarios for users only being able to see photos and albums connected to their account. 
- Modify photos controller to connect with current user. 